### PR TITLE
Add Cookie Consent & Compliance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Explore this curated selection of tools and take proactive steps towards securin
 - [Creator Tools](#creator-tools)
 - [Financial Support Platforms](#financial-support-platforms)
 - [Analytics](#analytics)
+- [Cookie Consent & Compliance](#cookie-consent--compliance)
 - [Cryptocurrencies & Wallets](#cryptocurrencies--wallets)
 - [Email Client](#email-client)
 - [File Sharing & Syncing](#file-sharing--syncing)
@@ -516,6 +517,12 @@ Plausible Analytics is a lightweight and privacy-friendly alternative to traditi
 
 #### [Matomo](https://matomo.org/)
 Matomo, formerly known as Piwik, is a comprehensive, open-source analytics platform. It offers full ownership of your analytics data, with privacy and security at its core. Matomo provides detailed reports without compromising user privacy.
+
+### Cookie Consent & Compliance
+
+#### [Best Consent Management Platforms](https://github.com/JermainKroot/best-consent-management-platforms)
+
+An independent, hands-on comparison of 9 consent management platforms (CMPs) — including OneTrust, Cookiebot, Iubenda, My Agile Privacy, Didomi, and others — tested on over 25 real websites over 3 months. Evaluates GDPR and ePrivacy compliance accuracy, setup complexity, performance impact, TCF 2.x and Google Consent Mode v2 support, and pricing. No affiliate links or sponsored content — purely experience-based.
 
 ### Cryptocurrencies & Wallets
 


### PR DESCRIPTION
This PR adds a new "Cookie Consent & Compliance" section, placed logically after the existing Analytics section.

The added resource is an independent, no-affiliate comparison of 9 CMPs tested hands-on across 25+ real websites. It covers GDPR/ePrivacy compliance accuracy, setup time, performance impact, TCF 2.x and Google Consent Mode v2 support, and pricing — useful for anyone managing a website and needing to choose the right consent tool.

The list currently covers analytics privacy (Plausible, Matomo) but lacks resources on the complementary topic of consent management, which is a core part of any privacy-respecting web setup.